### PR TITLE
Add build and testing automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Test
+        run: make test
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - '*'
+
+name: Test
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Test
+        run: make test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,24 +3,20 @@ before:
     - go mod download
     - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
-- goos:
-  - darwin
-  - linux
-  - windows
-- goarch:
-  - amd64
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
 archives:
-- replacements:
-    amd64: x86_64
+  - replacements:
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
+snapshot:
+  name_template: '{{ .Tag }}-SNAPSHOT'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+builds:
+- env:
+  - CGO_ENABLED=0
+- goos:
+  - darwin
+  - linux
+  - windows
+- goarch:
+  - amd64
+archives:
+- replacements:
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSIONS_PACKAGE := github.com/galaho/pathogen/versions
+ROOT := $(shell git rev-parse --show-toplevel)
 
 COMMIT := $(shell git rev-parse --verify --short HEAD 2> /dev/null || echo "UNKNOWN")
 COMMIT_FLAG := -X $(VERSIONS_PACKAGE).commit=$(COMMIT)
@@ -35,3 +36,8 @@ test: vendor
 vendor:
 	@echo "--> Vendoring dependencies..."
 	@CGO_ENABLED=0 go mod vendor
+
+.PHONY: ci
+ci:
+	@echo "--> Testing the CI..."
+	@docker run --rm -v $(ROOT):/go/src/github.com/galaho/pathogen -w /go/src/github.com/galaho/pathogen goreleaser/goreleaser release --snapshot


### PR DESCRIPTION
I can't add much in the way of golang, but I can add some automation.  

This PR adds testing automation for every commit and adds automatic releasing for every tag. 

The output of goreleaser is slightly different than what you have now; you can see an example in my fork: https://github.com/chrisbsmith/pathogen/releases/tag/v9.9.11

